### PR TITLE
Improvements to interaction system

### DIFF
--- a/Assets/Hertzole/Gold Player/Scripts/Interaction/GoldPlayerInteraction.cs
+++ b/Assets/Hertzole/Gold Player/Scripts/Interaction/GoldPlayerInteraction.cs
@@ -52,8 +52,8 @@ namespace Hertzole.GoldPlayer.Interaction
         // How it should behave with triggers.
         private QueryTriggerInteraction m_TriggerInteraction = QueryTriggerInteraction.Ignore;
 
-        // The current hit transform.
-        private Transform m_CurrentHit;
+        // The current hit collider.
+        private Collider m_CurrentHit;
 
         // The current hit interactable.
         public GoldPlayerInteractable CurrentHitInteractable { get; private set; }
@@ -111,17 +111,23 @@ namespace Hertzole.GoldPlayer.Interaction
 #endif
         {
             // Do the raycast.
-            if (Physics.Raycast(m_CameraHead.position, m_CameraHead.forward, out m_InteractableHit, m_InteractionRange, m_InteractionLayer, m_TriggerInteraction))
+            if (Physics.Raycast(
+                m_CameraHead.position,
+                m_CameraHead.forward,
+                out m_InteractableHit,
+                m_InteractionRange,
+                m_InteractionLayer,
+                m_TriggerInteraction))
             {
                 // If there's no hit transform, stop here.
-                if (m_InteractableHit.transform == null)
+                if (m_InteractableHit.collider == null)
                     return;
 
                 // If there's no current hit or the hits doesn't match, update it and
                 // the player need to check for a interactable again.
-                if (m_CurrentHit == null || m_CurrentHit != m_InteractableHit.transform)
+                if (m_CurrentHit == null || m_CurrentHit != m_InteractableHit.collider)
                 {
-                    m_CurrentHit = m_InteractableHit.transform;
+                    m_CurrentHit = m_InteractableHit.collider;
                     m_HaveCheckedInteractable = false;
                 }
 
@@ -129,7 +135,11 @@ namespace Hertzole.GoldPlayer.Interaction
                 // We don't want to call GetComponent every frame, you know!
                 if (!m_HaveCheckedInteractable)
                 {
-                    CurrentHitInteractable = m_InteractableHit.transform.GetComponent<GoldPlayerInteractable>();
+                    // Prefer interactables on the collider itself, but if the collider doesn't
+                    // have one, then look on the rigidbody.
+                    CurrentHitInteractable =
+                        m_InteractableHit.collider.GetComponent<GoldPlayerInteractable>() ??
+                        m_InteractableHit.rigidbody.GetComponent<GoldPlayerInteractable>();
                     m_HaveCheckedInteractable = true;
                 }
 


### PR DESCRIPTION
First off: thanks for the great base controller. It's been lovely having something to drop in for prototyping. I assume I'll customize it a bunch for our game but this has been the simplest drop-in controller I've found that actually feels good.

So this change fixes a bug I encountered whereby nested interactables were un-interactable because the interaction system assumed that the collider and the transform were the same object. In my case I had this hierarchy:

- Elevator (just a kinematic rigid body)
  - Room (the mesh of the interior)
  - Button (the interactable item was here)

With the old code it saw that I was looking at the button but used the Elevator's transform because that's the transform of the rigid body itself. This change switches to tracking the collider the player is looking at and prefers interactable components on the collider over interactable components on the rigidbody.